### PR TITLE
feat: create interface for video component

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,9 @@ export const VIDEO_PARAMETERS = {
  * dataSetup: video.js modifiers, which will be passed on to video.js.
  */
 export interface VideoProps extends HTMLVideoElement {
-  src: string;
   domain?: string;
   dataSetup?: string;
+  height: string;
+  src: string;
+  width: string;
 }


### PR DESCRIPTION
This PR adds the initial interface for what the video component will look like. Specifically, what properties it will accept and what their corresponding values will be. This interface describes the component-specific properties in addition to any attributes found natively on the [video element](https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.htmlvideoelement.html).

## Point(s) worth discussing
Internal discussion had originally suggested the following interface instead:
```js
dataSource: string
domain?: string
dataSetup?: string
```

I wanted to suggest that we consider naming that requires little less mental overhead for users to understand. I think `src` would be a good candidate for being the main prop users pass the video URL to, however @luqven did point out that it may not be webcomponent-compliant as it is a native attribute on the [element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#simple_video_example). To that end, I'm open to any other suggestions on the specific naming here.

