### PR TITLE
chore: remove hard-coded element id

### DIFF
--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -4,11 +4,7 @@ import {createRef, ref} from 'lit/directives/ref.js';
 import videojs, {VideoJsPlayerOptions} from 'video.js';
 import 'video.js/dist/video-js.css';
 import {convertDataSetupStringToObject} from '~/converters';
-import {
-  buildAttributeMap,
-  generateUid,
-  spreadHostAttributesToElement,
-} from '~/helpers';
+import {buildAttributeMap, spreadHostAttributesToElement} from '~/helpers';
 import {DataSetup} from '~/types';
 
 /**
@@ -78,7 +74,6 @@ export class IxVideo extends LitElement {
    * we've disabled the shadow dom.
    */
   @state()
-  uid = generateUid();
   options = {} as DataSetup;
 
   /**
@@ -111,7 +106,6 @@ export class IxVideo extends LitElement {
       <video
         ${ref(this.videoRef)}
         class="video-js vjs-default-skin ${this.className}"
-        id="ix-video-${this.uid}"
         part="video"
       ></video>
     `;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,14 +1,5 @@
 import type {LitElement} from 'lit';
 
-export const generateUid = function () {
-  let ID = '';
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-  for (let i = 0; i < 12; i++) {
-    ID += characters.charAt(Math.floor(Math.random() * 36));
-  }
-  return ID;
-};
-
 /**
  * Build a Map of the Lit element's attributes and their values.
  * @param customElement - The customElement to read the attributes from.


### PR DESCRIPTION
This commmit removed the `generateUID` function and `uid` state value.
It also removes the inline `id` attriute being set on the `video`
element. This is because VJS will generate a unqiue `id` for us on the
fly. We're actually increasing the chances of a id collision by doing
this ourselves.