### PR TITLE
feat: react to props change

### DIFF
--- a/cypress/integration/ix-video/props.spec.ts
+++ b/cypress/integration/ix-video/props.spec.ts
@@ -1,0 +1,89 @@
+import {PLAYER_WITH_CONTAINER} from '../../fixtures/selectors';
+
+context('ix-video: styles', () => {
+  before(() => {
+    cy.visit('/props.html');
+  });
+
+  const host = PLAYER_WITH_CONTAINER;
+
+  describe('when source property is updated', () => {
+    it('should update the video source', () => {
+      cy.get(host).then(($el) => {
+        const oldSrc = $el.find('video').attr('src');
+        const newSrc =
+          'https://assets.imgix.video/videos/girl-reading-book-in-library.mp4?fm=hls';
+        $el.attr('source', newSrc);
+        cy.wait(500).then(() => {
+          const currentSrc = $el.find('video').attr('src');
+          expect(currentSrc).to.not.equal(oldSrc);
+        });
+      });
+    });
+  });
+
+  describe('when the fixed property is updated', () => {
+    it('should set the fixed property to the new value', () => {
+      cy.get(host).then(($el) => {
+        $el.removeAttr('fixed');
+        cy.wait(1000).then(() => {
+          console.log($el.find('[part="video"]').attr('class'));
+          const fluid = $el.find('[part="video"]').hasClass('vjs-fluid');
+          expect(fluid).to.equal(true);
+          $el.attr('fixed', '');
+        });
+      });
+    });
+  });
+
+  describe('when the controls property is updated', () => {
+    it('should set the controls property to the new value', () => {
+      cy.get(host).then(($el) => {
+        $el.removeAttr('controls');
+        cy.wait(1000).then(() => {
+          console.log($el.find('[part="video"]').attr('class'));
+          const hasControls = $el
+            .find('[part="video"]')
+            .hasClass('vjs-controls-enabled');
+          expect(hasControls).to.equal(false);
+        });
+      });
+    });
+  });
+
+  describe('when width property is updated', () => {
+    it('should update the video width', () => {
+      cy.get(host).then(($el) => {
+        const oldWidth = $el.find('video').css('width');
+        const newWidth = '500';
+        $el.attr('width', newWidth);
+        cy.wait(500).then(() => {
+          const currentWidth = $el.find('video').css('width');
+          const fluid = $el.find('[part="video"]').hasClass('vjs-fluid');
+          expect(currentWidth).to.not.equal(undefined);
+          expect(currentWidth).to.not.equal(oldWidth);
+          expect(currentWidth).to.equal(newWidth + 'px');
+          expect(fluid).to.equal(false);
+        });
+      });
+    });
+  });
+
+  describe('when height property is updated', () => {
+    it('should update the video height', () => {
+      cy.get(host).then(($el) => {
+        const oldHeight = $el.find('video').css('height');
+        const newHeight = '500';
+        $el.attr('height', newHeight);
+        cy.wait(500).then(() => {
+          const currentHeight = $el.find('video').css('height');
+          const fluid = $el.find('[part="video"]').hasClass('vjs-fluid');
+          expect(currentHeight).to.not.equal(undefined);
+          expect(currentHeight).to.not.equal(oldHeight);
+          expect(currentHeight).to.equal(newHeight + 'px');
+          expect(fluid).to.equal(false);
+        });
+      });
+    });
+  });
+});

--- a/cypress/integration/ix-video/props.spec.ts
+++ b/cypress/integration/ix-video/props.spec.ts
@@ -1,6 +1,6 @@
 import {PLAYER_WITH_CONTAINER} from '../../fixtures/selectors';
 
-context('ix-video: styles', () => {
+context('ix-video: props', () => {
   before(() => {
     cy.visit('/props.html');
   });
@@ -27,7 +27,6 @@ context('ix-video: styles', () => {
       cy.get(host).then(($el) => {
         $el.removeAttr('fixed');
         cy.wait(1000).then(() => {
-          console.log($el.find('[part="video"]').attr('class'));
           const fluid = $el.find('[part="video"]').hasClass('vjs-fluid');
           expect(fluid).to.equal(true);
           $el.attr('fixed', '');
@@ -41,7 +40,6 @@ context('ix-video: styles', () => {
       cy.get(host).then(($el) => {
         $el.removeAttr('controls');
         cy.wait(1000).then(() => {
-          console.log($el.find('[part="video"]').attr('class'));
           const hasControls = $el
             .find('[part="video"]')
             .hasClass('vjs-controls-enabled');

--- a/dev/props.html
+++ b/dev/props.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <!-- HLS video that fills container -->
+    <div style="display: flex; width: 480px; height: 255px">
+      <ix-video
+        class="my-custom-class"
+        data-test-id="ix-video-with-container"
+        source="https://assets.imgix.video/videos/girl-reading-book-in-library.mp4"
+        controls
+        fixed
+      ></ix-video>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -299,6 +299,10 @@ export class IxVideo extends LitElement {
     this.options = this._getOptions();
     const {controls, height, width, fixed} = this.options;
 
+    // update component styles
+    const newStyles = this._getStyles(this.options);
+    this._setStyles(newStyles);
+
     // For each changed property, update the the vjsPlayer attribute value
     changed.forEach((_, propName) => {
       if (propName === 'source') {

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -83,10 +83,11 @@ export class IxVideo extends LitElement {
    * @see https://docs.videojs.com/tutorial-options.html
    */
   @property({
-    type: String,
     attribute: 'data-setup',
+    converter: (value: string | null) =>
+      convertDataSetupStringToObject(value ?? ''),
   })
-  dataSetup: string | undefined = undefined;
+  dataSetup: DataSetup = {};
 
   @property({type: Boolean})
   fixed = false;

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -122,7 +122,13 @@ export class IxVideo extends LitElement {
     fluid: !this.fixed,
   } as DataSetup;
   vjsPlayer: videojs.Player | undefined = undefined;
-
+  styles: CSSStyleDeclaration = {
+    // set the host width and height
+    width: this.options.width ? this.options.width + 'px' : '100%',
+    height: this.options.height ? this.options.height + 'px' : '100%',
+    // Need to set a display value otherwise w/h styles are not applied
+    display: 'block',
+  } as CSSStyleDeclaration;
   /**
    * ------------------------------------------------------------------------
    * Instance Methods

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -1,4 +1,4 @@
-import {html, LitElement} from 'lit';
+import {html, LitElement, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {createRef, ref} from 'lit/directives/ref.js';
 import videojs, {VideoJsPlayerOptions} from 'video.js';

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -114,7 +114,13 @@ export class IxVideo extends LitElement {
    * options. Storing this in state keeps the component properties from being
    * overwritten.
    */
-  options = {} as DataSetup;
+  options = {
+    width: this.width ?? 'auto',
+    height: this.height ?? 'auto',
+    controls: this.controls,
+    sources: this.source ? [{src: this.source, type: this.type}] : [],
+    fluid: !this.fixed,
+  } as DataSetup;
   vjsPlayer: videojs.Player | undefined = undefined;
 
   /**

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -250,14 +250,37 @@ export class IxVideo extends LitElement {
       ...this.dataSetup,
     };
   };
-       * If the offsetWidth is 0, in other words there is no measurable
-       * containing element height, we set the width value to 'auto'. This
-       * allows VideoJS to fallback to rendering the video at its original size.
-       */
-      this.style.width = '100%'; // update the host element width
-      this.options.width = this.offsetWidth || 'auto'; // update the video element width
-    } else {
-      /**
+
+  /**
+   * Create a CSSStyleDeclaration object from the state styles and the width and
+   * height properties. Ensure the width and height are either set to `px` or `%`
+   * values.
+   *
+   * @param {DataSetup} options - data-setup options
+   * @returns {CSSStyleDeclaration} CSSStyleDeclaration style object
+   */
+  private _getStyles = (options: DataSetup) => {
+    return {
+      ...this.styles,
+      width: options.width ? options.width + 'px' : '100%',
+      height: options.height ? options.height + 'px' : '100%',
+    };
+  };
+
+  /**
+   * Update the host style properties to match the style object.
+   * @param {CSSStyleDeclaration} styles - CSSStyleDeclaration style object
+   * @returns {void} void;
+   */
+  private _setStyles = (styles: CSSStyleDeclaration) => {
+    for (const key in styles) {
+      if (styles.hasOwnProperty(key)) {
+        const value = styles[key];
+        this.style.setProperty(key, value);
+      }
+    }
+  };
+
        * When the `width` and `height` properties are set, we want change the
        * host elements dimensions to match.
        */

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -297,7 +297,7 @@ export class IxVideo extends LitElement {
     super.updated(changed);
 
     this.options = this._getOptions();
-    const {controls, height, width, fixed} = this.options;
+    const {controls, height, width, fluid} = this.options;
 
     // update component styles
     const newStyles = this._getStyles(this.options);
@@ -317,10 +317,10 @@ export class IxVideo extends LitElement {
         this.vjsPlayer?.height(Number(height));
       }
       if (propName === 'width' && width) {
-        this.vjsPlayer?.height(Number(width));
+        this.vjsPlayer?.width(Number(width));
       }
       if (propName === 'fixed') {
-        this.vjsPlayer?.fluid(!fixed);
+        this.vjsPlayer?.fluid(!!fluid);
       }
     });
   }

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -83,11 +83,12 @@ export class IxVideo extends LitElement {
    * @see https://docs.videojs.com/tutorial-options.html
    */
   @property({
+    type: Object,
     attribute: 'data-setup',
     converter: (value: string | null) =>
       convertDataSetupStringToObject(value ?? ''),
   })
-  dataSetup: DataSetup = {};
+  dataSetup = {};
 
   @property({type: Boolean})
   fixed = false;

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -220,18 +220,30 @@ export class IxVideo extends LitElement {
       });
     });
 
-    if (!this.options.width) {
-      /**
-       * When the `width` and `height` properties are not set, we want to mimic
-       * video.js' ability to take up 100% of the containing elements w/h.
-       *
-       * Because our player is contained inside a custom element, we need to
-       * manually set the width of the host _and_ the video element to be 100%
-       * of the containing element.
-       *
-       * Because videojs doesn't understand percentages, instead we approximate
-       * 100% width value by setting the value to the element's offsetWidth.
-       *
+  /**
+   * Get the updated video player's options and merge them with the data-setup
+   * options.
+   *
+   * Merging the data-setup options with the element options allows users to
+   * set VJS-specific options on the element. We assume users will not set the
+   * same option twice, and explain as much in the docs.
+   *
+   * @see https://docs.videojs.com/tutorial-options.html
+   * @returns {void} void;
+   * @private
+   * @memberof IxVideo
+   */
+  private _getOptions = () => {
+    return {
+      ...this.options,
+      width: this.width ?? '',
+      height: this.height ?? '',
+      controls: this.controls,
+      sources: this.source ? [{src: this.source, type: this.type}] : [],
+      fluid: !this.fixed,
+      ...this.dataSetup,
+    };
+  };
        * If the offsetWidth is 0, in other words there is no measurable
        * containing element height, we set the width value to 'auto'. This
        * allows VideoJS to fallback to rendering the video at its original size.

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -276,14 +276,50 @@ export class IxVideo extends LitElement {
     }
   };
 
-       * When the `width` and `height` properties are set, we want change the
-       * host elements dimensions to match.
-       */
-      this.style.width = this.options.width + 'px';
-      if (this.options.height) {
-        this.style.height = this.options.height + 'px';
+  /**
+   * ------------------------------------------------------------------------
+   * Render Lifecycle Methods
+   * ------------------------------------------------------------------------
+   */
+  override render() {
+    return html`
+      <video
+        ${ref(this.videoRef)}
+        class="video-js vjs-default-skin vjs-big-play-centered ${this
+          .className}"
+        id="ix-video-${this.uid}"
+        part="video"
+      ></video>
+    `;
+  }
+
+  override updated(changed: PropertyValues<this>) {
+    super.updated(changed);
+
+    this.options = this._getOptions();
+    const {controls, height, width, fixed} = this.options;
+
+    // For each changed property, update the the vjsPlayer attribute value
+    changed.forEach((_, propName) => {
+      if (propName === 'source') {
+        this.vjsPlayer?.src(
+          this.source ? [{src: this.source, type: this.type}] : []
+        );
       }
-    }
+      if (propName === 'controls') {
+        this.vjsPlayer?.controls(!!controls);
+      }
+      if (propName === 'height' && height) {
+        this.vjsPlayer?.height(Number(height));
+      }
+      if (propName === 'width' && width) {
+        this.vjsPlayer?.height(Number(width));
+      }
+      if (propName === 'fixed') {
+        this.vjsPlayer?.fluid(!fixed);
+      }
+    });
+  }
 
   override firstUpdated(): void {
     const player = this.videoRef?.value as HTMLVideoElement;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@ export interface DataSetup
   extends Omit<VideoJsPlayerOptions, 'width' | 'height'> {
   width?: number | string;
   height?: number | string;
+  fixed?: boolean;
 }


### PR DESCRIPTION
This is a major refactor that aimed to enable reacting to properties changing during the lifetime of a component.

This PR:

1. refactor state so that modification is done at the last possible second of both state and properties
2. makes use of state and converters to set the shape of properties as early and consistently as possible
3. introduces an `updated()` hook that enables us to update properties in response to an attribute change.
4. Centers the big play button

## Video


https://user-images.githubusercontent.com/16711614/166345409-e4f5c1bd-60d7-437b-9b18-1c672c26e8d1.mov




<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-2246
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#34|feat: bubble-up video events to ix-video|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/34?label=Pending)|-|
|#35|refactor: ensure unset attrs not set to emtpy str|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/35?label=Pending)|#34|
|#36|test: refactor tests into sep specs|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/36?label=Pending)|#35|
|#37|test: ix-video react integration tests|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/37?label=Pending)|#36|
|#39|feat: make video sizing responsive by default|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/39?label=Pending)|#37|
|#38|👉feat: react to props change|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/38?label=Pending)|#39|
|#40|~~test: ensure props change is reflected on video~~|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/40?label=%20)|#38|
<!---GHSTACKCLOSE-->




