### PR TITLE
[PE-2246] test: ensure props change is reflected on video

### DIFF
--- a/cypress/integration/ix-video/props.spec.ts
+++ b/cypress/integration/ix-video/props.spec.ts
@@ -1,0 +1,89 @@
+import {PLAYER_WITH_CONTAINER} from '../../fixtures/selectors';
+
+context('ix-video: styles', () => {
+  before(() => {
+    cy.visit('/props.html');
+  });
+
+  const host = PLAYER_WITH_CONTAINER;
+
+  describe('when source property is updated', () => {
+    it('should update the video source', () => {
+      cy.get(host).then(($el) => {
+        const oldSrc = $el.find('video').attr('src');
+        const newSrc =
+          'https://assets.imgix.video/videos/girl-reading-book-in-library.mp4?fm=hls';
+        $el.attr('source', newSrc);
+        cy.wait(500).then(() => {
+          const currentSrc = $el.find('video').attr('src');
+          expect(currentSrc).to.not.equal(oldSrc);
+        });
+      });
+    });
+  });
+
+  describe('when the fixed property is updated', () => {
+    it('should set the fixed property to the new value', () => {
+      cy.get(host).then(($el) => {
+        $el.removeAttr('fixed');
+        cy.wait(1000).then(() => {
+          console.log($el.find('[part="video"]').attr('class'));
+          const fluid = $el.find('[part="video"]').hasClass('vjs-fluid');
+          expect(fluid).to.equal(true);
+          $el.attr('fixed', '');
+        });
+      });
+    });
+  });
+
+  describe('when the controls property is updated', () => {
+    it('should set the controls property to the new value', () => {
+      cy.get(host).then(($el) => {
+        $el.removeAttr('controls');
+        cy.wait(1000).then(() => {
+          console.log($el.find('[part="video"]').attr('class'));
+          const hasControls = $el
+            .find('[part="video"]')
+            .hasClass('vjs-controls-enabled');
+          expect(hasControls).to.equal(false);
+        });
+      });
+    });
+  });
+
+  describe('when width property is updated', () => {
+    it('should update the video width', () => {
+      cy.get(host).then(($el) => {
+        const oldWidth = $el.find('video').css('width');
+        const newWidth = '500';
+        $el.attr('width', newWidth);
+        cy.wait(500).then(() => {
+          const currentWidth = $el.find('video').css('width');
+          const fluid = $el.find('[part="video"]').hasClass('vjs-fluid');
+          expect(currentWidth).to.not.equal(undefined);
+          expect(currentWidth).to.not.equal(oldWidth);
+          expect(currentWidth).to.equal(newWidth + 'px');
+          expect(fluid).to.equal(false);
+        });
+      });
+    });
+  });
+
+  describe('when height property is updated', () => {
+    it('should update the video height', () => {
+      cy.get(host).then(($el) => {
+        const oldHeight = $el.find('video').css('height');
+        const newHeight = '500';
+        $el.attr('height', newHeight);
+        cy.wait(500).then(() => {
+          const currentHeight = $el.find('video').css('height');
+          const fluid = $el.find('[part="video"]').hasClass('vjs-fluid');
+          expect(currentHeight).to.not.equal(undefined);
+          expect(currentHeight).to.not.equal(oldHeight);
+          expect(currentHeight).to.equal(newHeight + 'px');
+          expect(fluid).to.equal(false);
+        });
+      });
+    });
+  });
+});

--- a/dev/props.html
+++ b/dev/props.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <!-- HLS video that fills container -->
+    <div style="display: flex; width: 480px; height: 255px">
+      <ix-video
+        class="my-custom-class"
+        data-test-id="ix-video-with-container"
+        source="https://assets.imgix.video/videos/girl-reading-book-in-library.mp4"
+        controls
+        fixed
+      ></ix-video>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -299,6 +299,10 @@ export class IxVideo extends LitElement {
     this.options = this._getOptions();
     const {controls, height, width, fixed} = this.options;
 
+    // update component styles
+    const newStyles = this._getStyles(this.options);
+    this._setStyles(newStyles);
+
     // For each changed property, update the the vjsPlayer attribute value
     changed.forEach((_, propName) => {
       if (propName === 'source') {

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -297,7 +297,7 @@ export class IxVideo extends LitElement {
     super.updated(changed);
 
     this.options = this._getOptions();
-    const {controls, height, width, fixed} = this.options;
+    const {controls, height, width, fluid} = this.options;
 
     // update component styles
     const newStyles = this._getStyles(this.options);
@@ -317,10 +317,10 @@ export class IxVideo extends LitElement {
         this.vjsPlayer?.height(Number(height));
       }
       if (propName === 'width' && width) {
-        this.vjsPlayer?.height(Number(width));
+        this.vjsPlayer?.width(Number(width));
       }
       if (propName === 'fixed') {
-        this.vjsPlayer?.fluid(!fixed);
+        this.vjsPlayer?.fluid(!!fluid);
       }
     });
   }

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -83,11 +83,12 @@ export class IxVideo extends LitElement {
    * @see https://docs.videojs.com/tutorial-options.html
    */
   @property({
+    type: Object,
     attribute: 'data-setup',
     converter: (value: string | null) =>
       convertDataSetupStringToObject(value ?? ''),
   })
-  dataSetup: DataSetup = {};
+  dataSetup = {};
 
   @property({type: Boolean})
   fixed = false;


### PR DESCRIPTION
## Before this PR
- there were no properties changes tests
- the `update()` lifecycle had typos that led to incorrect property updates

## After this PR
- we have property updating tests
- the properties that before had typos are now updated correctly

<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-2246
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#34|feat: bubble-up video events to ix-video|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/34?label=Pending)|-|
|#35|refactor: ensure unset attrs not set to emtpy str|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/35?label=Pending)|#34|
|#36|test: refactor tests into sep specs|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/36?label=Pending)|#35|
|#37|test: ix-video react integration tests|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/37?label=Pending)|#36|
|#39|feat: make video sizing responsive by default|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/39?label=Pending)|#37|
|#38|feat: react to props change|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/38?label=Pending)|#39|
|#40|👉test: ensure props change is reflected on video|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/40?label=Pending)|#38|
<!---GHSTACKCLOSE-->

