### PR TITLE
[PE-2247] feat: add controlled poster prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ index.js
 index.js.map
 index.d.ts
 index.d.ts.map
+pairing.md

--- a/cypress/integration/ix-video/poster.spec.ts
+++ b/cypress/integration/ix-video/poster.spec.ts
@@ -1,0 +1,44 @@
+import {PLAYER_WITH_CONTAINER} from '../../fixtures/selectors';
+
+context('ix-video: poster', () => {
+  before(() => {
+    cy.visit('/poster.html');
+  });
+
+  const ixVideoTag = PLAYER_WITH_CONTAINER;
+
+  describe('`<ix-video>` tag poster property', () => {
+    it('should update when prop changes', () => {
+      cy.get(ixVideoTag).then(($ixVideo) => {
+        $ixVideo.attr('poster', 'https://sdk-test.imgix.net/amsterdam.jpg');
+        const poster = $ixVideo.attr('poster');
+        expect(poster).to.equal('https://sdk-test.imgix.net/amsterdam.jpg');
+      });
+    });
+    it('should append width/height params to poster URL equal to video size', () => {
+      cy.get(ixVideoTag).then(($ixVideo) => {
+        const videoTag = $ixVideo.find('[part=video]');
+        const videoTagWith = videoTag.css('width').split('px')[0];
+        const videoTagHeight = videoTag.css('height').split('px')[0];
+        cy.get('.vjs-poster').should(
+          'have.css',
+          'background-image',
+          `url("https://sdk-test.imgix.net/amsterdam.jpg?w=${videoTagWith}&h=${videoTagHeight}")`
+        );
+      });
+    });
+    it('should not accept relative URLs', () => {
+      cy.get(ixVideoTag).then(($ixVideo) => {
+        const videoTag = $ixVideo.find('[part=video]');
+        const videoTagWith = videoTag.css('width').split('px')[0];
+        const videoTagHeight = videoTag.css('height').split('px')[0];
+        $ixVideo.attr('poster', '../../fixtures/amsterdam.jpg');
+        cy.get('.vjs-poster').should(
+          'have.css',
+          'background-image',
+          `url("https://sdk-test.imgix.net/amsterdam.jpg?w=${videoTagWith}&h=${videoTagHeight}")`
+        );
+      });
+    });
+  });
+});

--- a/dev/ReactApp.tsx
+++ b/dev/ReactApp.tsx
@@ -15,23 +15,42 @@ const dataSetup = JSON.stringify({
 });
 
 export function App() {
+  const [hasControls, setHadControls] = React.useState(true);
+  const [fixed, setFixed] = React.useState(false);
+  const [playerWidth, setPlayerWidth] = React.useState(0);
   // eslint-disable-next-line
   const handleEvent = (e: any, type: string) => {
     console.log('ix-video: ' + type, e);
+  };
+  const handleClick = () => {
+    setHadControls(!hasControls);
+  };
+  const handleFixed = () => {
+    setFixed(!fixed);
+  };
+
+  const updateWith = () => {
+    setPlayerWidth(playerWidth + 100);
   };
   return (
     <>
       <div className="App">
         <header className="App-header">
+          <button onClick={handleClick}>Toggle controls</button>
+          <button onClick={handleFixed}>Toggle fixed</button>
+          <button onClick={updateWith}>Increase width +100</button>
           <div className="mobile">
             <Video
-              controls
+              controls={hasControls}
               source="https://assets.imgix.video/videos/girl-reading-book-in-library.mp4"
               data-setup={dataSetup}
               data-test-id="react-player"
               className="my-custom-class"
               onError={(e) => handleEvent(e, 'error')}
               onSeeked={(e) => handleEvent(e, 'seeked')}
+              poster="https://sdk-test.imgix.net/amsterdam.jpg"
+              width={playerWidth ? playerWidth + '' : undefined}
+              fixed={fixed}
             />
           </div>
         </header>

--- a/dev/poster.html
+++ b/dev/poster.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <!-- HLS video that fills container -->
+    <div style="display: flex; width: 480px; height: 255px">
+      <ix-video
+        data-test-id="ix-video-with-container"
+        source="https://assets.imgix.video/videos/girl-reading-book-in-library.mp4"
+        controls
+        width="400"
+        poster="https://sdk-test.imgix.net/%26%24%2B%2C%3A%3B%3D%3F%40%23.jpg"
+      ></ix-video>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a `poster` property that when changed re-renders to reflect the changes. The poster is also sized to the dimension of the video on the first render.

## Video 📹

https://user-images.githubusercontent.com/16711614/166826959-5f4abf08-fc8f-4b5a-b284-1cc121b5cd06.mov



<!---GHSTACKOPEN-->
### Stacked PR Chain: PE-2247
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#41|refactor: remove options state & ref prop directly|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/41?label=Pending)|-|
|#42|👉feat: add controlled poster prop|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/42?label=Pending)|#41|
<!---GHSTACKCLOSE-->
