### PR TITLE
[f1] build: use vite to build bundle

### DIFF
--- a/dev/ReactApp.tsx
+++ b/dev/ReactApp.tsx
@@ -1,6 +1,6 @@
 import {createComponent} from '@lit-labs/react';
-import {IxVideo} from '../src/index';
-
+// import {IxVideo} from '../src/index';
+import {IxVideo} from '../dist/index.bundled';
 //eslint-disable-next-line
 const React = (window as any).React as typeof import('react');
 //eslint-disable-next-line

--- a/package-lock.json
+++ b/package-lock.json
@@ -7763,9 +7763,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -9597,9 +9597,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9609,7 +9609,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -21647,9 +21647,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -28729,9 +28729,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -30065,9 +30065,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -39251,9 +39251,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
   "bugs": {
     "url": "https://github.com/imgix/vue/issues"
   },
-  "main": "/dist/index.cjs.bundled.js",
-  "module": "/dist/index.bundled.js",
-  "jsnext:main": "/dist/index.bundled.js",
-  "unpkg": "dist/imgix-vue.min.js",
+  "main": "/dist/index.bundled.mjs",
+  "module": "/dist/index.bundled.mjs",
+  "jsnext:main": "/dist/index.bundled.mjs",
+  "unpkg": "dist/index.bundled.umd.js",
   "type": "module",
   "files": [
-    "/dist",
+    "/dist/index.bundled.mjs",
+    "/dist/index.bundled.umd.js",
     "/src",
     "README.md",
     "CHANGELOG.md",
@@ -23,10 +24,11 @@
     "custom-elements.json"
   ],
   "scripts": {
-    "build": "rollup -c rollup.config.mjs",
-    "build:watch": "rollup -c rollup.config.mjs --watch",
+    "build": "npm run build:rollup && vite build",
+    "build:rollup": "rollup -c rollup.config.mjs",
+    "build:watch": "vite build --watch",
     "dev": "vite --config ./dev/vite.config.ts",
-    "dev:prod": "vite --mode production --config ./dev/vite.config.ts",
+    "preview": "vite preview --mode production",
     "lint": "npm run lint:lit-analyzer && npm run lint:eslint",
     "lint:eslint": "eslint 'src/**/*.ts'",
     "lint:lit-analyzer": "lit-analyzer",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,13 +22,8 @@ export default {
   output: [
     // ES bundle
     {
-      file: './dist/index.bundled.js',
+      file: './dist/index.bundled.mjs',
       format: 'esm',
-    },
-    // IIFE bundle
-    {
-      file: './dist/index.cjs.bundled.js',
-      format: 'cjs',
     },
   ],
   onwarn(warning) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,14 +11,14 @@ export default defineConfig({
     },
   },
   build: {
+    emptyOutDir: false,
     cssCodeSplit: true,
     lib: {
       name: 'lib',
       entry: resolve(__dirname, 'src/index.ts'),
-      formats: ['umd'],
+      formats: ['umd', 'es'],
       fileName: (format) => {
         if (format === 'es') return `index.bundled.mjs`;
-        if (format === 'cjs') return `index.bundled.cjs`;
         return `index.bundled.${format}.js`;
       },
     },


### PR DESCRIPTION
Prior to this commit, rollup was being use to bundle the application directly. This was 1) slow and 2) difficult to use when trying to also support UMD modules. 

The CJS and ES dependencies that are used in this project don't play nicely with the `commonjs()` rollup plugin, making it difficult to create a UMD bundle. Using vite side-steps this issue.

The one major drawback here is that the CSS cannot be inlined into the JS. So we have to both 1) provde an index.css file that includes the videojs styles and 2) check if it's being used and fallback to using a `<link>` tag that references the CSS if it's not.
<!---GHSTACKOPEN-->
### Stacked PR Chain: f1
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#46|*(Draft)fix: detect if vjs css present*|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/46?label=Pending)|-|
|#47|👉 *(Draft)build: use vite to build bundle*|![](https://img.shields.io/github/pulls/detail/state/imgix/web-components/47?label=Pending)|#46|
<!---GHSTACKCLOSE-->
