### PR TITLE
feat: import vjs styles using static attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,16 +5,4 @@
 /docs/node_modules
 custom-elements.json
 # top level source
-ix-video.js
-ix-video.js.map
-ix-video.d.ts
-ix-video.d.ts.map
-ix-gif.js
-ix-gif.js.map
-ix-gif.d.ts
-ix-gif.d.ts.map
-index.js
-index.js.map
-index.d.ts
-index.d.ts.map
 pairing.md

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,19 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+import './commands';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,6 @@
         "video.js": "^7.18.1"
       },
       "devDependencies": {
-        "@babel/core": "^7.17.10",
-        "@babel/plugin-proposal-class-properties": "^7.16.7",
-        "@babel/plugin-proposal-decorators": "^7.17.9",
-        "@babel/preset-env": "^7.17.10",
         "@custom-elements-manifest/analyzer": "^0.5.7",
         "@cypress/vite-dev-server": "^2.2.2",
         "@esm-bundle/chai": "^4.1.5",
@@ -24,7 +20,6 @@
         "@lit-labs/react": "^1.0.4",
         "@open-wc/testing": "^3.0.0-next.1",
         "@open-wc/testing-karma": "^4.0.9",
-        "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^21.0.2",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/plugin-replace": "^3.0.0",
@@ -39,7 +34,6 @@
         "@typescript-eslint/eslint-plugin": "^4.3.0",
         "@typescript-eslint/parser": "^4.30.0",
         "@webcomponents/webcomponentsjs": "^2.6.0",
-        "babel-plugin-external-helpers": "^6.22.0",
         "concurrently": "^7.1.0",
         "conventional-changelog-conventionalcommits": "^4.6.3",
         "cypress": "^9.6.0",
@@ -51,6 +45,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.28.2",
         "rollup-plugin-postcss": "^4.0.2",
+        "rollup-plugin-postcss-lit": "^2.0.0",
         "rollup-plugin-summary": "^1.2.3",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-ts": "^2.0.5",
@@ -668,26 +663,6 @@
         "@babel/core": "^7.12.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.17.9.tgz",
-      "integrity": "sha512-EfH2LZ/vPa2wuPwJ26j+kYRkaubf89UlwxKXtxqEm57HrgSEYDB8t4swFP+p8LcI9yiP9ZRJJjo/58hS6BnaDA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.17.9",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/plugin-syntax-decorators": "^7.17.0",
-        "charcodes": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
@@ -917,21 +892,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.17.0.tgz",
-      "integrity": "sha512-qWe85yCXsvDEluNP0OyeQjH63DlhAR3W7K9BxxU1MvbDb48tgBG+Ao6IJJ6smPDrrVzSQZrbF6donpkFBMcs3A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3270,29 +3230,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.2.tgz",
@@ -5008,6 +4945,26 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/aes-decrypter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.2.tgz",
@@ -5431,15 +5388,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "node_modules/babel-plugin-external-helpers": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
-      "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
-      "dev": true,
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
     "node_modules/babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -5502,22 +5450,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
-    },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
     },
     "node_modules/backo2": {
       "version": "1.0.2",
@@ -5868,6 +5800,12 @@
       "engines": {
         "node": ">= 10.16.0"
       }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "dev": true
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -6322,15 +6260,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/charcodes": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/charcodes/-/charcodes-0.2.0.tgz",
-      "integrity": "sha512-Y4kiDb+AM4Ecy58YkuZrrSRJBDQdQ2L+NyS1vHHFtNtUjgutcZfx3yp1dAONI/oPaPmyGfCLx5CxL+zauIMyKQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/check-more-types": {
@@ -7265,14 +7194,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
-      "hasInstallScript": true
-    },
     "node_modules/core-js-bundle": {
       "version": "3.17.2",
       "resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.17.2.tgz",
@@ -7706,6 +7627,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+      "dev": true
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -10338,6 +10265,27 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -13481,6 +13429,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-source-map": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.5.6"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -14055,6 +14012,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/mutexify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
+      "integrity": "sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==",
+      "dev": true,
+      "dependencies": {
+        "queue-tick": "^1.0.0"
+      }
+    },
     "node_modules/mux.js": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
@@ -14080,6 +14046,86 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanobench": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nanobench/-/nanobench-2.1.1.tgz",
+      "integrity": "sha512-z+Vv7zElcjN+OpzAxAquUayFLGK3JI/ubCl0Oh64YQqsTGG09CGqieJVQw4ui8huDnnAgrvTv93qi5UaOoNj8A==",
+      "dev": true,
+      "dependencies": {
+        "browser-process-hrtime": "^0.1.2",
+        "chalk": "^1.1.3",
+        "mutexify": "^1.1.0",
+        "pretty-hrtime": "^1.0.2"
+      },
+      "bin": {
+        "nanobench": "run.js",
+        "nanobench-compare": "compare.js"
+      }
+    },
+    "node_modules/nanobench/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanobench/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanobench/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanobench/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/nanobench/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nanobench/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/nanoid": {
@@ -18308,6 +18354,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/printable-characters": {
       "version": "1.0.42",
       "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
@@ -18449,6 +18504,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+      "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
+      "dev": true
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -19332,6 +19393,35 @@
       "peerDependencies": {
         "postcss": "8.x"
       }
+    },
+    "node_modules/rollup-plugin-postcss-lit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss-lit/-/rollup-plugin-postcss-lit-2.0.0.tgz",
+      "integrity": "sha512-z6F5bmJJNOZGtZ+J3NRx3EDSatr/Nu5h1e5Of2mbUmACiNc+Apv/yVh09QHiKzJuwslb7EmKQm0o+mwfKYSVag==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.1.0",
+        "transform-ast": "^2.4.4"
+      }
+    },
+    "node_modules/rollup-plugin-postcss-lit/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-postcss-lit/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/rollup-plugin-postcss/node_modules/pify": {
       "version": "5.0.0",
@@ -21477,6 +21567,53 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/transform-ast": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/transform-ast/-/transform-ast-2.4.4.tgz",
+      "integrity": "sha512-AxjeZAcIOUO2lev2GDe3/xZ1Q0cVGjIMk5IsriTy8zbWlsEnjeB025AhkhBJHoy997mXpLd4R+kRbvnnQVuQHQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn-node": "^1.3.0",
+        "convert-source-map": "^1.5.1",
+        "dash-ast": "^1.0.0",
+        "is-buffer": "^2.0.0",
+        "magic-string": "^0.23.2",
+        "merge-source-map": "1.0.4",
+        "nanobench": "^2.1.1"
+      }
+    },
+    "node_modules/transform-ast/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/transform-ast/node_modules/magic-string": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.23.2.tgz",
+      "integrity": "sha512-oIUZaAxbcxYIp4AyLafV6OVKoB3YouZs0UTCJ8mOKBHNyJgGDaMJ4TgA+VylJh6fx7EQCC52XkbURxxG9IoJXA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.1"
+      }
+    },
     "node_modules/traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -23180,20 +23317,6 @@
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       }
     },
-    "@babel/plugin-proposal-decorators": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.17.9.tgz",
-      "integrity": "sha512-EfH2LZ/vPa2wuPwJ26j+kYRkaubf89UlwxKXtxqEm57HrgSEYDB8t4swFP+p8LcI9yiP9ZRJJjo/58hS6BnaDA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.17.9",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/plugin-syntax-decorators": "^7.17.0",
-        "charcodes": "^0.2.0"
-      }
-    },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
@@ -23345,15 +23468,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
-    "@babel/plugin-syntax-decorators": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.17.0.tgz",
-      "integrity": "sha512-qWe85yCXsvDEluNP0OyeQjH63DlhAR3W7K9BxxU1MvbDb48tgBG+Ao6IJJ6smPDrrVzSQZrbF6donpkFBMcs3A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -25184,16 +25298,6 @@
         }
       }
     },
-    "@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
-      }
-    },
     "@rollup/plugin-commonjs": {
       "version": "21.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.2.tgz",
@@ -26625,6 +26729,23 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true
+    },
     "aes-decrypter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.2.tgz",
@@ -26951,15 +27072,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "babel-plugin-external-helpers": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
-      "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -27008,24 +27120,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.1"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
       }
     },
     "backo2": {
@@ -27301,6 +27395,12 @@
       "requires": {
         "duplexer": "0.1.1"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -27621,12 +27721,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
-    },
-    "charcodes": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/charcodes/-/charcodes-0.2.0.tgz",
-      "integrity": "sha512-Y4kiDb+AM4Ecy58YkuZrrSRJBDQdQ2L+NyS1vHHFtNtUjgutcZfx3yp1dAONI/oPaPmyGfCLx5CxL+zauIMyKQ==",
       "dev": true
     },
     "check-more-types": {
@@ -28349,12 +28443,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "dev": true
-    },
     "core-js-bundle": {
       "version": "3.17.2",
       "resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.17.2.tgz",
@@ -28688,6 +28776,12 @@
           "dev": true
         }
       }
+    },
+    "dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -30628,6 +30722,23 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-bigints": {
@@ -33129,6 +33240,15 @@
         }
       }
     },
+    "merge-source-map": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.6"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -33562,6 +33682,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "mutexify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
+      "integrity": "sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==",
+      "dev": true,
+      "requires": {
+        "queue-tick": "^1.0.0"
+      }
+    },
     "mux.js": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
@@ -33580,6 +33709,66 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "nanobench": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nanobench/-/nanobench-2.1.1.tgz",
+      "integrity": "sha512-z+Vv7zElcjN+OpzAxAquUayFLGK3JI/ubCl0Oh64YQqsTGG09CGqieJVQw4ui8huDnnAgrvTv93qi5UaOoNj8A==",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^0.1.2",
+        "chalk": "^1.1.3",
+        "mutexify": "^1.1.0",
+        "pretty-hrtime": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "nanoid": {
@@ -36612,6 +36801,12 @@
         }
       }
     },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
+    },
     "printable-characters": {
       "version": "1.0.42",
       "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
@@ -36710,6 +36905,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "queue-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+      "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
       "dev": true
     },
     "quick-lru": {
@@ -37415,6 +37616,34 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
           "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-postcss-lit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss-lit/-/rollup-plugin-postcss-lit-2.0.0.tgz",
+      "integrity": "sha512-z6F5bmJJNOZGtZ+J3NRx3EDSatr/Nu5h1e5Of2mbUmACiNc+Apv/yVh09QHiKzJuwslb7EmKQm0o+mwfKYSVag==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.1.0",
+        "transform-ast": "^2.4.4"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
           "dev": true
         }
       }
@@ -39130,6 +39359,38 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "transform-ast": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/transform-ast/-/transform-ast-2.4.4.tgz",
+      "integrity": "sha512-AxjeZAcIOUO2lev2GDe3/xZ1Q0cVGjIMk5IsriTy8zbWlsEnjeB025AhkhBJHoy997mXpLd4R+kRbvnnQVuQHQ==",
+      "dev": true,
+      "requires": {
+        "acorn-node": "^1.3.0",
+        "convert-source-map": "^1.5.1",
+        "dash-ast": "^1.0.0",
+        "is-buffer": "^2.0.0",
+        "magic-string": "^0.23.2",
+        "merge-source-map": "1.0.4",
+        "nanobench": "^2.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.23.2",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.23.2.tgz",
+          "integrity": "sha512-oIUZaAxbcxYIp4AyLafV6OVKoB3YouZs0UTCJ8mOKBHNyJgGDaMJ4TgA+VylJh6fx7EQCC52XkbURxxG9IoJXA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.1"
+          }
+        }
       }
     },
     "traverse": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "bugs": {
     "url": "https://github.com/imgix/vue/issues"
   },
-  "main": "/dist/index.cjs.bundled.js",
+  "main": "/dist/index.bundled.js",
   "module": "/dist/index.bundled.js",
   "jsnext:main": "/dist/index.bundled.js",
-  "unpkg": "dist/imgix-vue.min.js",
+  "unpkg": "dist/index.bundled.js",
   "type": "module",
   "files": [
     "/dist",
@@ -22,6 +22,12 @@
     "LICENSE",
     "custom-elements.json"
   ],
+  "imports": {
+    "lit": "./node_modules/lit/index.js",
+    "lit/": "./node_modules/lit/",
+    "videojs": "./node_modules/video.js/dist/video.js",
+    "videojs/": "./node_modules/video.js/dist/"
+  },
   "scripts": {
     "build": "rollup -c rollup.config.mjs",
     "build:watch": "rollup -c rollup.config.mjs --watch",
@@ -67,10 +73,6 @@
     "video.js": "^7.18.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.17.10",
-    "@babel/plugin-proposal-class-properties": "^7.16.7",
-    "@babel/plugin-proposal-decorators": "^7.17.9",
-    "@babel/preset-env": "^7.17.10",
     "@custom-elements-manifest/analyzer": "^0.5.7",
     "@cypress/vite-dev-server": "^2.2.2",
     "@esm-bundle/chai": "^4.1.5",
@@ -78,7 +80,6 @@
     "@lit-labs/react": "^1.0.4",
     "@open-wc/testing": "^3.0.0-next.1",
     "@open-wc/testing-karma": "^4.0.9",
-    "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-replace": "^3.0.0",
@@ -93,7 +94,6 @@
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/parser": "^4.30.0",
     "@webcomponents/webcomponentsjs": "^2.6.0",
-    "babel-plugin-external-helpers": "^6.22.0",
     "concurrently": "^7.1.0",
     "conventional-changelog-conventionalcommits": "^4.6.3",
     "cypress": "^9.6.0",
@@ -105,6 +105,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.28.2",
     "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-postcss-lit": "^2.0.0",
     "rollup-plugin-summary": "^1.2.3",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-ts": "^2.0.5",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {getBabelOutputPlugin} from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import process from 'process';
 import postcss from 'rollup-plugin-postcss';
+import postcssLit from 'rollup-plugin-postcss-lit';
 import summary from 'rollup-plugin-summary';
-import {terser} from 'rollup-plugin-terser';
 import ts from 'rollup-plugin-ts';
 
 const devMode = process.env.NODE_ENV === 'development';
@@ -19,18 +18,10 @@ console.log(`${devMode ? 'development' : 'production'} mode bundle`);
 
 export default {
   input: './src/index.ts',
-  output: [
-    // ES bundle
-    {
-      file: './dist/index.bundled.js',
-      format: 'esm',
-    },
-    // IIFE bundle
-    {
-      file: './dist/index.cjs.bundled.js',
-      format: 'cjs',
-    },
-  ],
+  output: {
+    file: './dist/index.bundled.js',
+    format: 'esm',
+  },
   onwarn(warning) {
     if (warning.code !== 'THIS_IS_UNDEFINED') {
       console.error(`(!) ${warning.message}`);
@@ -40,34 +31,9 @@ export default {
     ts(),
     replace({'Reflect.decorate': 'undefined', preventAssignment: true}),
     resolve(),
-    terser({
-      ecma: 2017,
-      module: true,
-      warnings: true,
-      mangle: {
-        properties: {
-          regex: /^__/,
-        },
-      },
-    }),
-    postcss({
-      plugins: [],
-    }),
+    postcss(),
+    postcssLit(),
     commonjs(),
-    getBabelOutputPlugin({
-      presets: [
-        [
-          '@babel/env',
-          {
-            targets: {
-              // target browsers with module support
-              esmodules: true,
-            },
-            exclude: ['proposal-dynamic-import'],
-          },
-        ],
-      ],
-    }),
     summary(),
   ],
 };

--- a/src/elements/ix-video.ts
+++ b/src/elements/ix-video.ts
@@ -2,7 +2,9 @@ import {html, LitElement, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {createRef, ref} from 'lit/directives/ref.js';
 import videojs, {VideoJsPlayerOptions} from 'video.js';
-import 'video.js/dist/video-js.css';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - video-js.css is not typed
+import vjsStyles from 'video.js/dist/video-js.css';
 import {DefaultVideoEventsMap} from '~/constants';
 import {convertDataSetupStringToObject} from '~/converters';
 import {
@@ -27,6 +29,9 @@ import {DataSetup} from '~/types';
  */
 @customElement('ix-video')
 export class IxVideo extends LitElement {
+  // Will insert a style tag to the document head. If we had the shadow-dom
+  // enabled, this would mean the styles would be scoped to this component.
+  static override styles = vjsStyles;
   /**
    * ------------------------------------------------------------------------
    * Instance Variables

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 import {resolve} from 'path';
+import postcssLit from 'rollup-plugin-postcss-lit';
 import pkg from 'vite';
 const {defineConfig} = pkg;
 
 export default defineConfig({
   publicDir: false,
+  plugins: [postcssLit({include: ['**/*.css', '**/*.css?*']})],
   resolve: {
     alias: {
       '~': resolve(__dirname, './src'),


### PR DESCRIPTION
## Before this PR
- bundling did not follow web-component [best practices](https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm/#justin-s-checklist-for-publishing-web-components-to-npm-)
- vjs styles were being imported in a non-lit fashion
- .gitignore was out of sync
- cypress module was missing

## After this PR
- bundling tries to follow WC best practices (no modification, module only, etc)
- package.json field refer to the correct package (🤦🏼 _idk how in the heck I typed vue in there_)
- vjs styles are handled directly by lit and not injected into the head by bundler logic